### PR TITLE
Update WD publication dates

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
             </td>
             <td></td>
             <td class="current">
-              <a href="https://www.w3.org/TR/ambient-light/">22 May 2017</a>
+              <a href="https://www.w3.org/TR/ambient-light/">14 August 2017</a>
             </td>
             <td>
               Q2 2017
@@ -265,7 +265,7 @@
               (<a href="https://github.com/w3c/accelerometer/">GitHub</a>)
             </td>
             <td class="current">
-              <a href="https://www.w3.org/TR/accelerometer/">18 April 2017</a>
+              <a href="https://www.w3.org/TR/accelerometer/">14 August 2017</a>
             </td>
             <td colspan="4"></td>
             <td></td>
@@ -282,7 +282,7 @@
               (<a href="https://github.com/w3c/gyroscope/">GitHub</a>)
             </td>
             <td class="current">
-              <a href="https://www.w3.org/TR/gyroscope/">18 April 2017</a>
+              <a href="https://www.w3.org/TR/gyroscope/">14 August 2017</a>
             </td>
             <td colspan="4"></td>
             <td></td>
@@ -297,7 +297,7 @@
               (<a href="https://github.com/w3c/magnetometer/">GitHub</a>)
             </td>
             <td class="current">
-              <a href="https://www.w3.org/TR/magnetometer/">18 April 2017</a>
+              <a href="https://www.w3.org/TR/magnetometer/">14 August 2017</a>
             </td>
             <td colspan="4"></td>
             <td></td>
@@ -312,7 +312,7 @@
               (<a href="https://github.com/w3c/orientation-sensor/">GitHub</a>)
             </td>
             <td class="current">
-              <a href="https://www.w3.org/TR/orientation-sensor/">11 May
+              <a href="https://www.w3.org/TR/orientation-sensor/">14 August
               2017</a>
             </td>
             <td colspan="4"></td>


### PR DESCRIPTION
@xfq @dontcallmedom @fhirsch, this update bumps the WD dates to match the latest WD publications.

Related: https://github.com/w3c/motion-sensors/issues/28