### PR TITLE
Center the link inside a "table cell"

### DIFF
--- a/roadmap.html
+++ b/roadmap.html
@@ -58,6 +58,8 @@ layout: default
     }
 
     #roadmap > div.milestone {
+        display: flex;
+        align-items: center;
         font-size: 10px;
         padding-top: 11px;
         padding-bottom: 11px;


### PR DESCRIPTION
The HTML Media Capture Recommendation link in the lower right corner of https://www.w3.org/2009/dap/roadmap isn't centered in the "table cell". This patch fixes the issue.