### PR TITLE
Roadmap refresh

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -63,6 +63,13 @@ ul#navigation > li.active a {
     font-weight: bold;
     cursor: default;
 }
+ul#navigation > li a:before {
+    content: "⚪";
+}
+
+ul#navigation > li.active a:before {
+    content: "📍";
+}
 
 div#logo {
     background-image: url(../../assets/svg/mobile-sensors.svg);

--- a/roadmap.html
+++ b/roadmap.html
@@ -130,51 +130,51 @@ title: Roadmap
     <div class="ed maturity">Editor's Draft</div>
     <div class="wd maturity">Working Draft</div>
     <div class="sd maturity">Stable Draft</div>
-    <div class="cr maturity">Candidate Rec</div>
+    <div class="cr maturity">Candidate Rec (Draft)</div>
     <div class="pr maturity">Proposed Rec</div>
     <div class="rec maturity">Recommendation</div>
 
-    <div class="subheader">Sensor Framework<span>An abstract base class extended by concrete sensors.</span></div>
+    <div class="subheader" id="sensor-framework">⚙️ Sensor Framework<span>An abstract base class extended by concrete sensors.</span></div>
 
     <div class="spec"><a href="https://w3c.github.io/sensors/">Generic Sensor API</a><a href="https://github.com/w3c/sensors" class="gh">w3c/sensors</a></div>
     <div class="gh"><a href="https://w3c.github.io/sensors/" class="gh">ED</a></div>
     <div class="milestone done"></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2019/WD-generic-sensor-20190307/">7 Mar 2019</a></div>
-    <div class="milestone current"><a href="https://www.w3.org/TR/2019/CR-generic-sensor-20191212/">12 Dec 2019</a></div>
+    <div class="milestone done"></a></div>
+    <div class="milestone current cr"><a href="https://www.w3.org/TR/generic-sensor/">29 Jul 2021</a></div>
     <div class="milestone future">Q4 2021</div>
     <div class="milestone future">Q1 2022</div>
 
-    <div class="subheader" id="motion-sensors">Motion Sensors<span>Low-level sensors that measure orientation and motion.</span></div>
+    <div class="subheader" id="motion-sensors">🔄 Motion Sensors<span>Low-level sensors that measure orientation and motion.</span></div>
 
     <div class="spec"><a href="https://w3c.github.io/accelerometer/">Accelerometer</a><a href="https://github.com/w3c/accelerometer" class="gh">w3c/accelerometer</a></div>
     <div class="gh"><a href="https://w3c.github.io/accelerometer/" class="gh">ED</a></div>
     <div class="milestone done"></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2019/WD-accelerometer-20190307/">7 Mar 2019</a></div>
-    <div class="milestone current"><a href="https://www.w3.org/TR/2019/CR-accelerometer-20191212/">12 Dec 2019</a></div>
+    <div class="milestone done"></div>
+    <div class="milestone current cr"><a href="https://www.w3.org/TR/accelerometer/">2 Sep 2021</a></div>
     <div class="milestone future">Q4 2021</div>
     <div class="milestone future">Q1 2022</div>
 
     <div class="spec"><a href="https://w3c.github.io/gyroscope/">Gyroscope</a><a href="https://github.com/w3c/gyroscope" class="gh">w3c/gyroscope</a></div>
     <div class="gh"><a href="https://w3c.github.io/gyroscope/" class="gh">ED</a></div>
     <div class="milestone done"></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2019/WD-gyroscope-20190307/">7 Mar 2019</a></div>
-    <div class="milestone current"><a href="https://www.w3.org/TR/2019/CR-gyroscope-20191212/">12 Dec 2019</a></div>
+    <div class="milestone done"></div>
+    <div class="milestone current cr"><a href="https://www.w3.org/TR/gyroscope/">2 Sep 2021</a></div>
     <div class="milestone future">Q4 2021</div>
     <div class="milestone future">Q1 2022</div>
 
     <div class="spec"><a href="https://w3c.github.io/magnetometer/">Magnetometer</a><a href="https://github.com/w3c/magnetometer" class="gh">w3c/magnetometer</a></div>
     <div class="gh"><a href="https://w3c.github.io/magnetometer/" class="gh">ED</a></div>
     <div class="milestone done"></div>
-    <div class="milestone current"><a href="https://www.w3.org/TR/2019/WD-magnetometer-20190307/">7 Mar 2019</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2018/CR-magnetometer-20180320/">20 Mar 2018</a></div>
+    <div class="milestone current"><a href="https://www.w3.org/TR/magnetometer/">2 Sep 2021</a></div>
+    <div class="milestone future"></div>
     <div class="milestone future">Q4 2021</div>
     <div class="milestone future">Q1 2022</div>
 
     <div class="spec"><a href="https://w3c.github.io/orientation-sensor/">Orientation Sensor</a><a href="https://github.com/w3c/orientation-sensor" class="gh">w3c/orientation-sensor</a></div>
     <div class="gh"><a href="https://w3c.github.io/orientation-sensor/" class="gh">ED</a></div>
     <div class="milestone done"></div>
-    <div class="milestone current"><a href="https://www.w3.org/TR/orientation-sensor/">8 Jun 2021</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2019/CR-orientation-sensor-20191212/">12 Dec 2019</a></div>
+    <div class="milestone current"><a href="https://www.w3.org/TR/orientation-sensor/">2 Sep 2021</a></div>
+    <div class="milestone future"></div>
     <div class="milestone future">Q4 2021</div>
     <div class="milestone future">Q1 2022</div>
 
@@ -182,31 +182,31 @@ title: Roadmap
     <div class="gh"><a href="https://w3c.github.io/deviceorientation/" class="gh">ED</a></div>
     <div class="milestone done"></div>
     <div class="milestone current"><a href="https://www.w3.org/TR/2019/WD-orientation-event-20190416/">16 Apr 2019</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2016/CR-orientation-event-20160818/">18 Aug 2016</a></div>
+    <div class="milestone future"></div>
     <div class="milestone future">Q4 2021</div>
     <div class="milestone future">Q1 2022</div>
 
     <div class="spec"><a href="https://w3c.github.io/motion-sensors/">Motion Sensors Explainer</a><a href="https://github.com/w3c/motion-sensors" class="gh">w3c/motion-sensors</a></div>
     <div class="gh"><a href="https://w3c.github.io/motion-sensors/" class="gh">ED</a></div>
-    <div class="milestone current wd"><a href="https://www.w3.org/TR/motion-sensors/">30 Aug 2017</a></div>
+    <div class="milestone future"></div>
     <div class="milestone future"></div>
     <div class="milestone future"></div>
     <div class="milestone future"></div>
     <div class="milestone future"></div>
 
-    <div class="subheader" id="environment-sensors">Environment Sensors<span>Sensors that monitor changes in the environment.</span></div>
+    <div class="subheader" id="environment-sensors">📡 Environment Sensors<span>Sensors that monitor changes in the environment.</span></div>
 
     <div class="spec"><a href="https://w3c.github.io/ambient-light/">Ambient Light Sensor</a><a href="https://github.com/w3c/ambient-light" class="gh">w3c/ambient-light</a></div>
     <div class="gh"><a href="https://w3c.github.io/ambient-light/" class="gh">ED</a></div>
     <div class="milestone done"></div>
-    <div class="milestone current"><a href="https://www.w3.org/TR/ambient-light/">1 Jun 2021</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2018/CR-ambient-light-20180320/">20 Mar 2018</a></div>
+    <div class="milestone current"><a href="https://www.w3.org/TR/ambient-light/">3 Sep 2021</a></div>
+    <div class="milestone future"></div>
     <div class="milestone future">Q4 2021</div>
     <div class="milestone future">Q1 2022</div>
 
     <div class="spec"><a href="https://w3c.github.io/proximity/">Proximity Sensor</a><a href="https://github.com/w3c/proximity" class="gh">w3c/proximity</a></div>
     <div class="gh"><a href="https://w3c.github.io/proximity/" class="gh">ED</a></div>
-    <div class="milestone current wd"><a href="https://www.w3.org/TR/proximity/">1 Jun 2021</a></div>
+    <div class="milestone current wd"><a href="https://www.w3.org/TR/proximity/">3 Sep 2021</a></div>
     <div class="milestone future"></div>
     <div class="milestone future"></div>
     <div class="milestone future">Q4 2021</div>
@@ -214,27 +214,27 @@ title: Roadmap
 
     <div class="spec"><a href="https://w3c.github.io/geolocation-sensor/">Geolocation Sensor</a><a href="https://github.com/w3c/geolocation-sensor" class="gh">w3c/geolocation</a></div>
     <div class="gh"><a href="https://w3c.github.io/geolocation-sensor/" class="gh">ED</a></div>
-    <div class="milestone current wd"><a href="https://www.w3.org/TR/geolocation-sensor/">2 Jun 2021</a></div>
+    <div class="milestone current wd"><a href="https://www.w3.org/TR/geolocation-sensor/">2 Sep 2021</a></div>
     <div class="milestone future"></div>
     <div class="milestone future">Q2 2022</div>
     <div class="milestone future"></div>
     <div class="milestone future"></div>
 
-    <div class="subheader" id="devices">Devices<span>Features that interact with device hardware.</span></div>
+    <div class="subheader" id="devices">🔋 Device Capabilities<span>Features that interact with device hardware.</span></div>
 
     <div class="spec"><a href="https://w3c.github.io/battery/">Battery Status API</a><a href="https://github.com/w3c/battery/" class="gh">w3c/battery</a></div>
     <div class="gh"><a href="https://w3c.github.io/battery/" class="gh">ED</a></div>
     <div class="milestone done"></div>
-    <div class="milestone current"><a href="https://www.w3.org/TR/battery-status/">1 Jun 2021</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2016/CR-battery-status-20160707/">7 Jul 2016</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2016/PR-battery-status-20160329/">29 Mar 2016</a></div>
+    <div class="milestone current"><a href="https://www.w3.org/TR/battery-status/">31 Aug 2021</a></div>
+    <div class="milestone future"></div>
+    <div class="milestone future">Q4 2021</div>
     <div class="milestone future">Q1 2022</div>
 
     <div class="spec"><a href="https://w3c.github.io/screen-wake-lock/">Screen Wake Lock API</a><a href="https://github.com/w3c/screen-wake-lock/" class="gh">w3c/screen-wake-lock</a></div>
     <div class="gh"><a href="https://w3c.github.io/screen-wake-lock/" class="gh">ED</a></div>
     <div class="milestone done"></div>
-    <div class="milestone current"><a href="https://www.w3.org/TR/screen-wake-lock/">2 Jun 2021</a></div>
-    <div class="milestone future">Q4 2020</div>
+    <div class="milestone current"><a href="https://www.w3.org/TR/screen-wake-lock/">26 Aug 2021</a></div>
+    <div class="milestone future"></div>
     <div class="milestone future">Q4 2021</div>
     <div class="milestone future">Q1 2022</div>
 
@@ -242,45 +242,84 @@ title: Roadmap
     <div class="gh"><a href="https://w3c.github.io/system-wake-lock/" class="gh">ED</a></div>
     <div class="milestone done"></div>
     <div class="milestone future"></div>
-    <div class="milestone current cr"><a href="https://www.w3.org/TR/2017/CR-wake-lock-20171214/">14 Dec 2017</a></div>
+    <div class="milestone current cr"><a href="https://www.w3.org/TR/2017/CR-wake-lock-20171214/">Obsoleted</a></div>
     <div class="milestone future">Q4 2021</div>
     <div class="milestone future">Q1 2022</div>
 
     <div class="spec"><a href="https://w3c.github.io/device-posture/">Device Posture API</a><a href="https://github.com/w3c/device-posture/" class="gh">w3c/device-posture</a></div>
     <div class="gh"><a href="https://w3c.github.io/device-posture/" class="gh">ED</a></div>
-    <div class="milestone done"><a href="https://www.w3.org/TR/2020/WD-screen-fold-20201217/">17 Dec 2020</a></div>
-    <div class="milestone current"><a href="https://www.w3.org/TR/device-posture/">13 May 2021</a></div>
+    <div class="milestone done"></div>
+    <div class="milestone current"><a href="https://www.w3.org/TR/device-posture/">2 Aug 2021</a></div>
     <div class="milestone future"></div>
     <div class="milestone future"></div>
     <div class="milestone future"></div>
 
-    <div class="subheader" id="maintenance">Maintenance<span>Specifications in maintenance.</span></div>
+    <div class="subheader" id="tentative">🆕 Tentative<span><em>"Depending on the progress, including consideration for adequate implementation experience</a>, the Group may also produce W3C Recommendations for the following documents." (Charter 2021)</em></span></div>
+
+    <div class="spec"><a href="https://wicg.github.io/netinfo/">Network Information API</a><a href="https://github.com/wicg/netinfo/" class="gh">wicg/netinfo</a></div>
+    <div class="gh"><a href="https://wicg.github.io/netinfo/" class="gh">ED</a></div>
+
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+
+    <div class="spec"><a href="https://wicg.github.io/contact-api/spec/">Contact Picker API</a><a href="https://github.com/wicg/contact-api/" class="gh">wicg/contact-api</a></div>
+    <div class="gh"><a href="https://wicg.github.io/contact-api/spec/" class="gh">ED</a></div>
+
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+
+    <div class="spec"><a href="https://wicg.github.io/idle-detection/">Idle Detection API</a><a href="https://github.com/wicg/idle-detection/" class="gh">wicg/idle-detection</a></div>
+    <div class="gh"><a href="https://wicg.github.io/idle-detection/" class="gh">ED</a></div>
+
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+
+    <div class="spec"><a href="https://oyiptong.github.io/compute-pressure/">Compute Pressure API</a><a href="https://github.com/oyiptong/compute-pressure/" class="gh">oyiptong/compute-pressure</a></div>
+    <div class="gh"><a href="https://oyiptong.github.io/compute-pressure/" class="gh">ED</a></div>
+
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+
+
+    <div class="subheader" id="maintenance">🔧 Maintenance<span>Specifications in maintenance.</span></div>
 
     <div class="spec"><a href="https://w3c.github.io/geolocation-api/">Geolocation API</a><a href="https://github.com/w3c/geolocation-api/" class="gh">w3c/geolocation-api</a></div>
     <div class="gh"><a href="https://w3c.github.io/geolocation-api/" class="gh">ED</a></div>
 
-    <div class="milestone current"><a href="https://www.w3.org/TR/2021/WD-geolocation-20210527/">27 May 2021</a><sup><a href="https://www.w3.org/blog/news/archives/9079">NB</a></sup></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2009/WD-geolocation-API-20090707/">07 Jul 2009</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2010/CR-geolocation-API-20100907/">07 Sep 2010</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2012/PR-geolocation-API-20120510/">10 May 2012</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2016/REC-geolocation-API-20161108/">8 Nov 2016</a></div>
+    <div class="milestone done"><a href="https://www.w3.org/blog/news/archives/9079">Re-published</a></div>
+    <div class="milestone current"><a href="https://www.w3.org/TR/geolocation/">12 Aug 2021</a></div>
+    <div class="milestone future">Q4 2021</a></div>
+    <div class="milestone future">Q1 2022</a></div>
+    <div class="milestone future">Q2 2022</a></div>
 
-    <div class="subheader" id="completed">Completed<span>Completed specifications published as W3C Recommendations.</span></div>
+    <div class="subheader" id="completed">✅ Completed<span>Completed specifications published as W3C Recommendations.</span></div>
 
     <div class="spec"><a href="https://w3c.github.io/vibration/">Vibration API</a><a href="https://github.com/w3c/vibration/" class="gh">w3c/vibration</a></div>
     <div class="gh"><a href="https://w3c.github.io/vibration/" class="gh">ED</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2011/WD-vibration-20111117/">17 Nov 2011</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2014/WD-vibration-20140619/">19 Jun 2014</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2014/CR-vibration-20140909/">9 Sep 2014</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2016/PER-vibration-20160818/">18 Aug 2016</a></div>
+    <div class="milestone done"></div>
+    <div class="milestone done"></div>
+    <div class="milestone done"></div>
+    <div class="milestone done"></div>
     <div class="milestone current rec"><a href="https://www.w3.org/TR/2016/REC-vibration-20161018/">18 Oct 2016</a></div>
 
     <div class="spec"><a href="https://w3c.github.io/html-media-capture/">HTML Media Capture</a><a href="https://github.com/w3c/html-media-capture/" class="gh">w3c/html-media-capture</a></div>
     <div class="gh"><a href="https://w3c.github.io/html-media-capture/" class="gh">ED</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2012/WD-html-media-capture-20121213/">13 Dec 2012</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2014/WD-html-media-capture-20140619/">19 Jun 2014</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2017/CR-html-media-capture-20170831/">31 Aug 2017</a></div>
-    <div class="milestone"><a href="https://www.w3.org/TR/2017/PR-html-media-capture-20171128/">28 Nov 2017</a></div>
+    <div class="milestone done"></div>
+    <div class="milestone done"></div>
+    <div class="milestone done"></div>
+    <div class="milestone done"></div>
     <div class="milestone current rec"><a href="https://www.w3.org/TR/2018/REC-html-media-capture-20180201/">1 Feb 2018</a></div>
 
 </div>


### PR DESCRIPTION
FYI @xfq, a roadmap refresh that simplifies the view by showing the latest TR publication only.

(It'd be great to be able to automate the TR timestamp generation. I feel the TR date is useful in this overview, so I would prefer to keep it. Let this be an example how it could look like. Not sure if you have some ideas on how to best automate this. Maybe auto-generate an yaml file separately and feed that into the Jekyll templating engine?)