### PR TITLE
Advance Compute Pressure and Contact Picker API to Rec Track

### DIFF
--- a/roadmap.html
+++ b/roadmap.html
@@ -281,6 +281,24 @@ updateDates();
     <div class="milestone future"></div>
     <div class="milestone future"></div>
 
+    <div class="spec"><a href="https://w3c.github.io/contact-api/spec/">Contact Picker API</a><a href="https://github.com/w3c/contact-api/" class="gh">w3c/contact-api</a></div>
+    <div class="gh"><a href="https://w3c.github.io/contact-api/spec/" class="gh">ED</a></div>
+
+    <div class="milestone current wd"><a href="https://www.w3.org/TR/contact-api/">⌛</a></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+
+    <div class="spec"><a href="https://w3c.github.io/compute-pressure/">Compute Pressure API</a><a href="https://github.com/w3c/compute-pressure/" class="gh">w3c/compute-pressure</a></div>
+    <div class="gh"><a href="https://w3c.github.io/compute-pressure/" class="gh">ED</a></div>
+
+    <div class="milestone current wd"><a href="https://www.w3.org/TR/compute-pressure/">⌛</a></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+    <div class="milestone future"></div>
+
     <div class="subheader" id="tentative">🆕 Tentative<span><em>"Depending on the progress, including consideration for adequate implementation experience</a>, the Group may also produce W3C Recommendations for the following documents." (Charter 2022)</em></span></div>
 
     <div class="spec"><a href="https://wicg.github.io/netinfo/">Network Information API</a><a href="https://github.com/wicg/netinfo/" class="gh">wicg/netinfo</a></div>
@@ -292,26 +310,8 @@ updateDates();
     <div class="milestone future"></div>
     <div class="milestone future"></div>
 
-    <div class="spec"><a href="https://wicg.github.io/contact-api/spec/">Contact Picker API</a><a href="https://github.com/wicg/contact-api/" class="gh">wicg/contact-api</a></div>
-    <div class="gh"><a href="https://wicg.github.io/contact-api/spec/" class="gh">ED</a></div>
-
-    <div class="milestone future"></div>
-    <div class="milestone future"></div>
-    <div class="milestone future"></div>
-    <div class="milestone future"></div>
-    <div class="milestone future"></div>
-
     <div class="spec"><a href="https://wicg.github.io/idle-detection/">Idle Detection API</a><a href="https://github.com/wicg/idle-detection/" class="gh">wicg/idle-detection</a></div>
     <div class="gh"><a href="https://wicg.github.io/idle-detection/" class="gh">ED</a></div>
-
-    <div class="milestone future"></div>
-    <div class="milestone future"></div>
-    <div class="milestone future"></div>
-    <div class="milestone future"></div>
-    <div class="milestone future"></div>
-
-    <div class="spec"><a href="https://wicg.github.io/compute-pressure/">Compute Pressure API</a><a href="https://github.com/wicg/compute-pressure/" class="gh">wicg/compute-pressure</a></div>
-    <div class="gh"><a href="https://wicg.github.io/compute-pressure/" class="gh">ED</a></div>
 
     <div class="milestone future"></div>
     <div class="milestone future"></div>


### PR DESCRIPTION
@himorin I've staged this PR in anticipation of the FPWD publications.

Dependencies:
- https://wicg.github.io/compute-pressure/ is migrated to https://w3c.github.io/compute-pressure/
- Redirect https://github.com/WICG/wicg.github.io/pull/21 is deployed.

To be merged when the above-mentioned dependencies are satisfied:

- https://github.com/w3c/github-notify-ml-config/pull/248 (github-notify-ml sends [updates like this](https://www.w3.org/Search/Mail/Public/search?type-index=public-device-apis&index-type=t&keywords=Weekly&search=Search) to the WG's mailing list every Tuesday.)